### PR TITLE
FIXED: http_reply evaluates wrong predicate

### DIFF
--- a/http_header.pl
+++ b/http_header.pl
@@ -184,8 +184,8 @@ http_reply(What, Out) :-
 http_reply(Data, Out, HdrExtra) :-
 	http_reply(Data, Out, HdrExtra, _Code).
 
-http_reply(Status, Out, HdrExtra, Code) :-
-	http_status_reply(Status, Out, HdrExtra, [], Code).
+http_reply(Data, Out, HdrExtra, Code) :-
+	http_reply(Data, Out, HdrExtra, [], Code).
 
 http_reply(Data, Out, HdrExtra, _Context, Code) :-
 	byte_count(Out, C0),


### PR DESCRIPTION
Fix #8. Instead of evaluating http_status_reply/5, it should evaluate
http_reply/5 where backtracking will happen later.
