### PR TITLE
FIXED: Documentation of http_status_reply/[4,5]: moved_temporary/1.

### DIFF
--- a/http_header.pl
+++ b/http_header.pl
@@ -294,7 +294,7 @@ copy_stream(Out, In, Header, From, To) :-
 %	   - created(Location)
 %	   - forbidden(Url)
 %	   - moved(To)
-%	   - moved_temporarily(To)
+%	   - moved_temporary(To)
 %	   - no_content
 %	   - not_acceptable(WhyHtml)
 %	   - not_found(Path)


### PR DESCRIPTION
`moved_temporarily` should be changed to `moved_temporary`.
