### PR TITLE
ADDED: HTTPS support for the HTTP Unix daemon

### DIFF
--- a/README
+++ b/README
@@ -15,4 +15,4 @@ scalable embedded HTTP server.
 
     * ../../packages/http.pdf
     * ../../packages/examples/http contains some demos.
-    * http://www.swi-prolog.org/packages/http.html
+    * http://www.swi-prolog.org/pldoc/package/http.html

--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -137,7 +137,7 @@ events:
 %
 %	  $ --output=File :
 %	  Send output of the process to File.  By default, all
-%	  Prolog console output` is discarded.
+%	  Prolog console output is discarded.
 %
 %	  $ --fork[=Bool] :
 %	  If given as =|--no-fork|= or =|--fork=false|=, the process


### PR DESCRIPTION
This adds the new options `--https`, `--certfile`, `--keyfile` and `--password`, so that the Unix daemon can more  smoothly provide HTTPS support. Also contains two documentation fixes.

If necessary, please change any parts at your convenience. Thank you!
