### PR TITLE
Enhance Keep-alive connections in connection with bytes/2

### DIFF
--- a/http_exception.pl
+++ b/http_exception.pl
@@ -183,6 +183,7 @@ keep_alive(Reply, Connection) :-
 	).
 
 keep_alive(not_modified).
+keep_alive(bytes(_Type, _Bytes)).
 keep_alive(file(_Type, _File)).
 keep_alive(tmp_file(_Type, _File)).
 keep_alive(stream(_In, _Len)).

--- a/http_header.pl
+++ b/http_header.pl
@@ -241,7 +241,8 @@ http_reply_data(tmp_file(Type, File), Out, HdrExtra, Code) :- !,
 	reply_file(Out, File, Header).
 http_reply_data(bytes(Type, Bytes), Out, HdrExtra, Code) :- !,
 	phrase(reply_header(bytes(Type, Bytes), HdrExtra, Code), Header),
-	format(Out, '~s~s', [Header, Bytes]).
+	format(Out, '~s~s', [Header, Bytes]),
+	flush_output(Out).
 http_reply_data(stream(In, Len), Out, HdrExtra, Code) :- !,
 	phrase(reply_header(cgi_data(Len), HdrExtra, Code), Header),
 	copy_stream(Out, In, Header, 0, end).

--- a/http_stream.pl
+++ b/http_stream.pl
@@ -254,7 +254,7 @@ bytes, dispite the fact that the underlying stream may be longer.
 %	    * transfer_encoding(-Tranfer)
 %	    One of =chunked= or =none=.
 %	    * connection(-Connection)
-%	    One of =Keep-Alife= or =close=
+%	    One of =Keep-Alive= or =close=
 %	    * content_length(-ContentLength)
 %	    Total byte-size of the content.  Available in the close
 %	    handler if the transfer_encoding is =none=.
@@ -275,7 +275,7 @@ bytes, dispite the fact that the underlying stream may be longer.
 %	    from the =send_header= hook to send the reply header to the
 %	    client.
 %	    * connection(-Connection)
-%	    One of =Keep-Alife= or =close=.
+%	    One of =Keep-Alive= or =close=.
 %	    * transfer_encoding(-Tranfer)
 %	    One of =chunked= or =none=.  Initially set to =none=.  When
 %	    switching to =chunked= from the =header= hook, it calls the

--- a/http_wrapper.pl
+++ b/http_wrapper.pl
@@ -87,7 +87,7 @@ applications:
 %		* peer(+Peer)
 %		IP address of client
 %
-%	@param Close	Unified to one of =close=, =|Keep-Alife|= or
+%	@param Close	Unified to one of =close=, =|Keep-Alive|= or
 %			spawned(ThreadId).
 
 http_wrapper(Goal, In, Out, Close, Options) :-


### PR DESCRIPTION
First of all, this actually **enables** Keep-alive connections when replying with `bytes/2`. Second, by flushing the output after the bytes are sent, it prevents stalling the browser.

This fixes #33.
