### PR TITLE
consistency in keep-alive related comments and predicate names

### DIFF
--- a/cgi_stream.c
+++ b/cgi_stream.c
@@ -35,7 +35,7 @@ client.  In particular, we want to deal with:
 
     * Separating the header from the body of the reply
     * Chunked or traditional transfer encoding
-    * Connection management (Keep-alife)
+    * Connection management (Keep-alive)
     * Thread management
 
 The original HTTP infrastructure has an `accept thread' that accepts new
@@ -55,7 +55,7 @@ with the request, deciding on:
     * The final header
     * The transfer encoding (chunked/none)
     * The content encoding (octet/utf8)
-    * The connection (Keep-Alife/close)
+    * The connection (Keep-Alive/close)
 
 Now, the stream is placed in  full   buffering  mode  (SIO_FBUF). If the
 transfer encoding is 'chunked'  it  immediately   calls  the  hook using
@@ -133,7 +133,7 @@ typedef struct cgi_context
   record_t	    request;		/* Associated request term */
   record_t	    header;		/* Associated reply header term */
   atom_t	    transfer_encoding;	/* Current transfer encoding */
-  atom_t	    connection;		/* Keep alife? */
+  atom_t	    connection;		/* Keep alive? */
 					/* state */
   cgi_state	    state;		/* Current state */
 					/* data buffering */

--- a/http_open.pl
+++ b/http_open.pl
@@ -837,7 +837,7 @@ transfer_encoding_filter(_, In, In).
 %	True if Encoding is the value   of  the =|Transfer-encoding|= or
 %	=|Content-encoding|= header. Note that this   should  only cover
 %	=|Transfer-encoding|=, but in practice  the =|Content-encoding|=
-%	header is used -incorrectly- as a synonym.
+%	header is used -incorrectly- as a synonym by many servers.
 
 transfer_encoding(Lines, Encoding) :-
 	member(Line, Lines),

--- a/thread_httpd.pl
+++ b/thread_httpd.pl
@@ -563,7 +563,7 @@ open_client(requeue(In, Out, Goal, ClOpts),
 	    _, Goal, In, Out, Opts, ClOpts) :- !,
 	memberchk(peer(Peer), ClOpts),
 	option(keep_alive_timeout(KeepAliveTMO), Opts, 2),
-	check_keep_alife_connection(In, KeepAliveTMO, Peer, In, Out).
+	check_keep_alive_connection(In, KeepAliveTMO, Peer, In, Out).
 open_client(Message, Queue, Goal, In, Out, Opts,
 	    [ pool(client(Queue, Goal, In, Out)),
 	      timeout(Timeout)
@@ -592,13 +592,13 @@ report_error(E) :-
 	fail.
 
 
-%%	check_keep_alife_connection(+In, +TimeOut, +Peer, +In, +Out) is semidet.
+%%	check_keep_alive_connection(+In, +TimeOut, +Peer, +In, +Out) is semidet.
 %
 %	Wait for the client for at most  TimeOut seconds. Succeed if the
 %	client starts a new request within   this  time. Otherwise close
 %	the connection and fail.
 
-check_keep_alife_connection(In, TMO, Peer, In, Out) :-
+check_keep_alive_connection(In, TMO, Peer, In, Out) :-
 	stream_property(In, timeout(Old)),
 	set_stream(In, timeout(TMO)),
 	debug(http(keep_alive), 'Waiting for keep-alive ...', []),
@@ -680,7 +680,7 @@ current_message_level(Term, Level) :-
 %%	http_requeue(+Header)
 %
 %	Re-queue a connection to  the  worker   pool.  This  deals  with
-%	processing additional requests on keep-alife connections.
+%	processing additional requests on keep-alive connections.
 
 http_requeue(Header) :-
 	requeue_header(Header, ClientOptions),

--- a/thread_httpd.pl
+++ b/thread_httpd.pl
@@ -601,15 +601,15 @@ report_error(E) :-
 check_keep_alife_connection(In, TMO, Peer, In, Out) :-
 	stream_property(In, timeout(Old)),
 	set_stream(In, timeout(TMO)),
-	debug(http(keep_alife), 'Waiting for keep-alife ...', []),
+	debug(http(keep_alive), 'Waiting for keep-alive ...', []),
 	catch(peek_code(In, Code), E, true),
 	(   var(E),			% no exception
 	    Code \== -1			% no end-of-file
 	->  set_stream(In, timeout(Old)),
-	    debug(http(keep_alife), '\tre-using keep-alife connection', [])
+	    debug(http(keep_alive), '\tre-using keep-alive connection', [])
 	;   (   Code == -1
-	    ->	debug(http(keep_alife), '\tRemote closed keep-alife connection', [])
-	    ;	debug(http(keep_alife), '\tTimeout on keep-alife connection', [])
+	    ->	debug(http(keep_alive), '\tRemote closed keep-alive connection', [])
+	    ;	debug(http(keep_alive), '\tTimeout on keep-alive connection', [])
 	    ),
 	    close_connection(Peer, In, Out),
 	    fail


### PR DESCRIPTION
This changes several occurrences of `alife` to `alive` in keep-alive related comments and names.

One remaining issue: in `cgi_stream.c`, we have the atom `keep_alife`, with name `ATOM_keep_alife`. If possible, please rename these to `keep_alive` and `ATOM_keep_alive` respectively.
