### PR TITLE
FIXED: No longer interpret content-encoding as a synonym for transfer-encoding in cases where the content-type indicates that such an encoding is expected. Kuniaki Mukai.

### DIFF
--- a/http_open.pl
+++ b/http_open.pl
@@ -961,7 +961,9 @@ digits([]) -->
 %
 %	Get rest of input as an atom.
 
-rest(A,L,[]) :-
+rest(Atom) --> call(rest_).
+
+rest_(Atom, L, []) :-
 	atom_codes(A, L).
 
 

--- a/http_open.pl
+++ b/http_open.pl
@@ -838,14 +838,26 @@ transfer_encoding_filter(_, In, In).
 %	header.
 
 transfer_encoding(Lines, Encoding) :-
+	what_encoding(transfer_encoding, Lines, Encoding).
+
+what_encoding(What, Lines, Encoding) :-
 	member(Line, Lines),
-	phrase(transfer_encoding(Encoding0), Line), !,
-	debug(http(transfer_encoding), 'Transfer-encoding: ~w', [Encoding0]),
+	phrase((encoding_(What, Debug),rest(Encoding0)), Line), !,
+	debug(http(What), '~w: ~w', [Debug,Encoding0]),
 	Encoding = Encoding0.
 
-transfer_encoding(Encoding) -->
-	field('transfer-encoding'),
-	rest(Encoding).
+encoding_(content_encoding, 'Content-encoding') -->
+	field('content-encoding').
+encoding_(transfer_encoding, 'Transfer-encoding') -->
+	field('transfer-encoding').
+
+%%	content_encoding(+Lines, -Encoding) is semidet.
+%
+%	True if Encoding is the value of the =|Content-encoding|=
+%	header.
+
+content_encoding(Lines, Encoding) :-
+	what_encoding(content_encoding, Lines, Encoding).
 
 %%	read_header(+In:stream, -Version, -Code:int, -Comment:atom, -Lines:list) is det.
 %

--- a/http_open.pl
+++ b/http_open.pl
@@ -834,10 +834,8 @@ transfer_encoding_filter(_, In, In).
 
 %%	transfer_encoding(+Lines, -Encoding) is semidet.
 %
-%	True if Encoding is the value   of  the =|Transfer-encoding|= or
-%	=|Content-encoding|= header. Note that this   should  only cover
-%	=|Transfer-encoding|=, but in practice  the =|Content-encoding|=
-%	header is used -incorrectly- as a synonym by many servers.
+%	True if Encoding is the value of the =|Transfer-encoding|=
+%	header.
 
 transfer_encoding(Lines, Encoding) :-
 	member(Line, Lines),
@@ -846,9 +844,7 @@ transfer_encoding(Lines, Encoding) :-
 	Encoding = Encoding0.
 
 transfer_encoding(Encoding) -->
-	(   field('transfer-encoding')
-	;   field('content-encoding')
-	), !,
+	field('transfer-encoding'),
 	rest(Encoding).
 
 %%	read_header(+In:stream, -Version, -Code:int, -Comment:atom, -Lines:list) is det.


### PR DESCRIPTION
Realistically, "gzip" is the major content type where this is of interest. We can make `disable_encoding_filter/1` extensible if other such applications arise. Source:

https://technet.microsoft.com/en-us/library/cc995227.aspx
