### PR TITLE
read_pending_codes/3 --> get_pending_codes/3

### DIFF
--- a/test_proxy.pl
+++ b/test_proxy.pl
@@ -319,11 +319,11 @@ shovel_dispatch(Pair, SlaveRead, SlaveWrite, Control, [Stream|More]):-
             close(Control),
             throw(exit)
         ;   Stream == Pair
-	->  read_pending_codes(Stream, Bytes, []),
+	->  get_pending_codes(Stream, Bytes, []),
             format(SlaveWrite, '~s', [Bytes]),
             flush_output(SlaveWrite)
         ;   Stream == SlaveRead
-	->  read_pending_codes(Stream, Bytes, []),
+	->  get_pending_codes(Stream, Bytes, []),
             format(Pair, '~s', [Bytes]),
             flush_output(Pair)
         ;   Stream == Control


### PR DESCRIPTION
Rational: "read" is always used for complete Prolog terms. "get" is used for other I/O.
