### PR TITLE
Correct documentation of http_switch_protocol/2

### DIFF
--- a/http_dispatch.pl
+++ b/http_dispatch.pl
@@ -920,7 +920,7 @@ http_404(_Options, Request) :-
 
 %%	http_switch_protocol(:Goal, +Options)
 %
-%	Send an =|HTTP 101 Switching   Protocols"|= reply. After sending
+%	Send an =|"HTTP 101 Switching   Protocols"|= reply. After sending
 %	the  reply,  the  HTTP  library    calls   call(Goal,  InStream,
 %	OutStream), where InStream and OutStream are  the raw streams to
 %	the HTTP client. This allows the communication to continue using
@@ -941,8 +941,10 @@ http_404(_Options, Request) :-
 %	This predicate interacts with the server  library by throwing an
 %	exception.
 %
-%	@param	Options is reserved for future extensions.  It must be
-%		initialised to the empty list ([]).
+%	@param	Options is reserved for future extensions.  Currently, it
+%		must be the empty list ([]), or a list with a single element
+%		`headers(Hs)` where `Hs` is a list of =|Name(Value)|= terms
+%		that specify header fields of the reply.
 %	@throws	http_reply(switch_protocol(Goal, Options))
 
 http_switch_protocol(Goal, Options) :-

--- a/http_header.pl
+++ b/http_header.pl
@@ -365,7 +365,7 @@ status_reply(no_content, Out, HdrExtra, _Context, _Method, Code) :- !,
 	format(Out, '~s', [Header]).
 status_reply(switching_protocols(_Goal,Options), Out,
 	     HdrExtra0, _Context, _Method, Code) :- !,
-	option(header(Extra1), Options, []),
+	option(headers(Extra1), Options, []),
 	http_join_headers(HdrExtra0, Extra1, HdrExtra),
 	phrase(reply_header(status(switching_protocols), HdrExtra, Code), Header),
 	format(Out, '~s', [Header]).


### PR DESCRIPTION
The documentation of [**`http_switch_protocol/2`**](http://eu.swi-prolog.org/pldoc/man?predicate=http_switch_protocol/2) states:

> **Options** is reserved for future extensions. **It must be initialised to the empty list (`[]`).**

Looking at the code, it is clear that this need not be the case: It also works for a list containing the single element `header(Hs)`, where `Hs` is a list of `Name(Value)` terms, and this is in fact an important feature for transmitting additional header fields in the response. So, this can be easily documented.

However, I would like to go even further and change this to **`headers(Hs)`** (note the **`s`**), in perfect analogy to the `headers(Hs)` option of `http_open/3`.

This pull request implements both changes. Please merge if applicable. Thank you, and stay tuned for **proxying WebSocket connections** which need this exact feature!
