### PR TITLE
FIXED: Determinism of http_open_websocket/3 with given subprotocols.

### DIFF
--- a/websocket.pl
+++ b/websocket.pl
@@ -159,6 +159,7 @@ ws_client_options(Subprotocol, [mode(client), subprotocol(Subprotocol)]).
 
 add_subprotocols(OptionsIn, OptionsOut) :-
 	select_option(subprotocols(Subprotocols), OptionsIn, Options1),
+	!,
 	must_be(list(atom), Subprotocols),
 	atomic_list_concat(Subprotocols, ', ', Value),
 	OptionsOut = [ request_header('Sec-WebSocket-Protocol' = Value)


### PR DESCRIPTION
Test case:

```
?- URL = 'ws://html5rocks.websocket.org/echo',
   http_open_websocket(URL, WS, [subprotocols([binary])]).
```
