### PR TITLE
ADDED: http:sni/2 hook to support SNI for HTTPS servers with the Unix daemon

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -57,7 +57,8 @@
 
 :- multifile
 	http_server_hook/1,			% +Options
-	http_certificate_hook/3.		% +CertFile, +KeyFile, -Password
+	http_certificate_hook/3,		% +CertFile, +KeyFile, -Password
+	http:sni/2.				% +HostName, +SSLOptions
 
 /** <module> Run SWI-Prolog HTTP server as a Unix system daemon
 
@@ -453,9 +454,11 @@ merge_https_options(Options, [SSL|Options]) :-
 	),
 	read_file_to_string(CertFile, Certificate, []),
 	private_key(KeyFile, Passwd, Key),
+	findall(HostName-HostOptions, http:sni(HostName, HostOptions), SNIs),
 	SSL = ssl([ certificate(Certificate),
 		    cipher_list(CipherList),
-		    key(Key)
+		    key(Key),
+		    sni(SNIs)
 		  ]).
 
 private_key(KeyFile, Passwd, Key) :-
@@ -812,6 +815,15 @@ first_deadline(Interval, Deadline) :-
 %	Hook that is called to start the  HTTP server. This hook must be
 %	compatible to http_server(Handler,  Options).   The  default  is
 %	provided by start_server/1.
+
+
+%%	http:sni(+HostName, +SSLOptions) is multi.
+%
+%	Hook   to  provide   Server  Name   Indication  (SNI)   for  TLS
+%	servers. When  starting an HTTPS  server, all solutions  of this
+%	predicate  are   collected  and   passed  as  sni/1   option  to
+%	ssl_context/3.  This hook  is executed  _before_ privileges  are
+%	dropped.
 
 
 		 /*******************************


### PR DESCRIPTION
Please review and merge if applicable, possibly with a more suitable name.

The `_hook` postfix seems less appropriate than for other hooks in this case, since all solutions are collected, and possibly even several times, so I omitted it.

`https` may be a more suitable prefix than `http`...

I am following mostly the suggestion you gave in #55, only without the `_host` postfix because the host is actually the **first** argument.