### PR TITLE
Use new certificate_key_pairs/1 option of library(ssl).

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -436,9 +436,8 @@ merge_https_options(Options, [SSL|Options]) :-
     read_file_to_string(KeyFile, Key, []),
     findall(HostName-HostOptions, http:sni_options(HostName, HostOptions), SNIs),
     maplist(sni_contexts, SNIs),
-    SSL = ssl([ certificate(Certificate),
+    SSL = ssl([ certificate_key_pairs([Certificate-Key]),
                 cipher_list(CipherList),
-                key(Key),
                 password(Passwd),
                 sni_hook(http_unix_daemon:sni)
               ]).


### PR DESCRIPTION
A future patch will enable multiple simultaneous certificate types for the HTTP Unix daemon.