### PR TITLE
Revert "Use new certificate_key_pairs/1 option of library(ssl)."

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -436,8 +436,9 @@ merge_https_options(Options, [SSL|Options]) :-
     read_file_to_string(KeyFile, Key, []),
     findall(HostName-HostOptions, http:sni_options(HostName, HostOptions), SNIs),
     maplist(sni_contexts, SNIs),
-    SSL = ssl([ certificate_key_pairs([Certificate-Key]),
+    SSL = ssl([ certificate(Certificate),
                 cipher_list(CipherList),
+                key(Key),
                 password(Passwd),
                 sni_hook(http_unix_daemon:sni)
               ]).


### PR DESCRIPTION
This reverts commit 643d3cf1918c6ac179a4e25fa08c85165c3931d2.

Multiple certificates will be made available with a new API.