### PR TITLE
Update documentation regarding SSL

### DIFF
--- a/http.doc
+++ b/http.doc
@@ -743,7 +743,7 @@ Use SSL (Secure Socket Layer) rather than plain TCP/IP. A server created
 this way is accessed using the \const{https://} protocol. SSL allows for
 encrypted communication to avoid others from tapping the wire as well as
 improved authentication of client and server. The \arg{SSLOptions}
-option list is passed to ssl_init/3. The port option of the main option
+option list is passed to ssl_context/3. The port option of the main option
 list is forwarded to the SSL layer. See the \pllib{ssl} library for
 details.
 \end{description}

--- a/http.doc
+++ b/http.doc
@@ -743,8 +743,7 @@ Use SSL (Secure Socket Layer) rather than plain TCP/IP. A server created
 this way is accessed using the \const{https://} protocol. SSL allows for
 encrypted communication to avoid others from tapping the wire as well as
 improved authentication of client and server. The \arg{SSLOptions}
-option list is passed to ssl_context/3. The port option of the main option
-list is forwarded to the SSL layer. See the \pllib{ssl} library for
+option list is passed to ssl_context/3. See the \pllib{ssl} library for
 details.
 \end{description}
 

--- a/thread_httpd.pl
+++ b/thread_httpd.pl
@@ -172,12 +172,12 @@ self-signed SSL certificate.
 %   and HTTPS server, where the HTTP   server redirects to the HTTPS
 %   server for handling sensitive requests.
 
-http_server(Goal, M:Options) :-
-    select_option(port(Port), Options, Options1),
+http_server(Goal, M:Options0) :-
+    option(port(Port), Options0),
     !,
-    make_socket(Port, M:Options1, Options2),
-    create_workers(Options2),
-    create_server(Goal, Port, Options2),
+    make_socket(Port, M:Options0, Options),
+    create_workers(Options),
+    create_server(Goal, Port, Options),
     print_message(informational,
                   httpd_started_server(Port)).
 http_server(_Goal, _Options) :-


### PR DESCRIPTION
These patches update and correct the documentation of the HTTP&nbsp;&leftrightarrow;&nbsp;SSL interaction.

Also, the `port/1` option is now *retained* in the option list. This option may be the only way for plugins (SSL being a prominent example) to distinguish different servers that are started by the same&nbsp;process.

