### PR TITLE
FIXED: Make http:sni_options/2 work again, by importing library(ssl).

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -53,6 +53,7 @@
 :- use_module(library(main)).
 
 :- if(exists_source(library(http/http_ssl_plugin))).
+:- use_module(library(ssl)).
 :- use_module(library(http/http_ssl_plugin)).
 :- endif.
 


### PR DESCRIPTION
It is unclear to me how this worked at all previously (it did!), and
why it broke.  It is necessary to import `library(ssl)` due to the use
of `ssl_context/3` when using `http:sni_options/2`.