### PR TITLE
DOC: Correct default timeout for threaded HTTP servers.

### DIFF
--- a/http.doc
+++ b/http.doc
@@ -708,12 +708,11 @@ See also http_workers/2.
 
     \termitem{timeout}{+SecondsOrInfinite}
 Determines the maximum period of inactivity handling a request.  If no
-data arrives within the specified time since the last data arrived the
-connection raises an exception, the worker discards the client and
-returns to the pool-queue for a new client. Default is \const{infinite},
-making each worker wait forever for a request to complete.  Without a
-timeout, a worker may wait forever on an a client that doesn't complete
-its request.
+data arrives within the specified time since the last data arrived, the
+connection raises an exception, and the worker discards the client and
+returns to the pool-queue for a new client. If it is \const{infinite},
+a worker may wait forever on a client that doesn't complete its
+request. Default is 60~seconds.
 
     \termitem{keep_alive_timeout}{+SecondsOrInfinite}
 Maximum time to wait for new activity on \emph{Keep-Alive} connections.

--- a/http.doc
+++ b/http.doc
@@ -741,7 +741,8 @@ Use SSL (Secure Socket Layer) rather than plain TCP/IP. A server created
 this way is accessed using the \const{https://} protocol. SSL allows for
 encrypted communication to avoid others from tapping the wire as well as
 improved authentication of client and server. The \arg{SSLOptions}
-option list is passed to ssl_context/3. See the \pllib{ssl} library for
+option list is passed to ssl_context/3. The port option of the main option
+list is forwarded to the SSL~layer. See the \pllib{ssl} library for
 details.
 \end{description}
 


### PR DESCRIPTION
This was incorrectly documented as `infinite`, but is actually 60&nbsp;seconds.