### PR TITLE
FIXED: Correct setting name is StartLimitBurst.

### DIFF
--- a/examples/systemd-script.service
+++ b/examples/systemd-script.service
@@ -10,7 +10,7 @@ UMask=022
 Environment=LANG=en_US.utf8
 Restart=on-failure
 StartLimitInterval=60
-DefaultStartLimitBurst=5
+StartLimitBurst=5
 WorkingDirectory=/home/swipl/src/demo
 ExecStart=/usr/bin/swipl daemon.pl --no-fork --port=80 --user=www-data \
 	  --pidfile=/var/run/demo.pid --workers=16 --syslog=demo


### PR DESCRIPTION
DefaultStartLimitBurst is only admissible in system.conf.