### PR TITLE
SECURITY: The HTTP Unix daemon now uses a much more secure set of ciphers as default.

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -259,7 +259,10 @@ events:
 %
 %     $ --cipherlist=Ciphers :
 %     One or more cipher strings separated by colons. See the OpenSSL
-%     documentation for more information. Default is `DEFAULT`.
+%     documentation for more information. Starting with SWI-Prolog
+%     7.5.11, the default value is always a set of ciphers that was
+%     considered secure enough to prevent all critical attacks at the
+%     time of the SWI-Prolog release.
 %
 %     $ --interactive[=Bool] :
 %     If =true= (default =false=) implies =|--no-fork|= and presents
@@ -457,6 +460,24 @@ make_address(Spec, _, _, _, _) :-
 
 :- dynamic sni/3.
 
+% Secure ciphers must guarantee forward secrecy, and must mitigate all
+% known critical attacks. As of 2017, using the following ciphers
+% allows you to obtain grade A on https://www.ssllabs.com. For A+, you
+% must also enable HTTP Strict Transport Security (HSTS) by sending a
+% suitable header field in replies.
+%
+% Note that obsolete ciphers *must* be disabled to reliably prevent
+% protocol downgrade attacks.
+%
+% **BEWARE**: This list must be changed when attacks on these ciphers
+%             become known! Keep an eye on this setting and adapt it
+%             as necessary in the future.
+%
+
+secure_ciphers(Cs) :-
+    Cs = 'EECDH+AESGCM:EDH+AESGCM:EECDH+AES256:EDH+AES256:EECDH+CHACHA20:EDH+CHACHA20'.
+
+
 merge_https_options(Options, [SSL|Options]) :-
     (   option(certfile(CertFile), Options),
         option(keyfile(KeyFile), Options)
@@ -466,7 +487,8 @@ merge_https_options(Options, [SSL|Options]) :-
         prepare_https_certificate(CertFile, KeyFile, Passwd0)
     ;   Pairs = []
     ),
-    option(cipherlist(CipherList), Options, 'DEFAULT'),
+    secure_ciphers(SecureCiphers),
+    option(cipherlist(CipherList), Options, SecureCiphers),
     (   string(Passwd0)
     ->  Passwd = Passwd0
     ;   options_password(Options, Passwd)


### PR DESCRIPTION
The goal is to make setting up secure HTTPS servers easy for
users. With the new default, you obtain grade A at ssllabs.com for
your servers, whereas you previously obtained only F.

Future SWI-Prolog versions will likewise enable default ciphers that
are deemed secure at the time of the respective release, and at the
same time ensure compatibility with all but the most exotic or
outdated devices.

Note that obsolete ciphers *must* be disabled to reliably prevent
protocol downgrade attacks.