### PR TITLE
DONE: Reasoning about SSL client certificates with the HTTP Unix daemon.

### DIFF
--- a/http_unix_daemon.pl
+++ b/http_unix_daemon.pl
@@ -146,7 +146,6 @@ events:
   - http(post_server_start)
   Run _after_ starting the HTTP server.
 
-@tbd    Provide options for client certificates with SSL.
 @tbd    Cleanup issues wrt. loading and initialization of xpce.
 @see    The file <swi-home>/doc/packages/examples/http/linux-init-script
         provides a /etc/init.d script for controlling a server as a normal


### PR DESCRIPTION
To use SSL client certificates in the HTTP Unix daemon, simply use the
now available predicate ssl_set_options/3 to enable them in the hooks
that are called by the server upon creation or connection attempts.