### PR TITLE
DOC: JSON dict type tags aren't added by default

### DIFF
--- a/json.pl
+++ b/json.pl
@@ -490,13 +490,21 @@ stream_error_context(Stream, stream(Stream, Line, LinePos, CharNo)) :-
 %   _stringified_ if it is not an atom or string. Stringification is
 %   based on term_string/2.
 %
-%   The version 7 _dict_ type is supported as well. If the dicts has
-%   a _tag_, a property "type":"tag" is   added  to the object. This
-%   behaviour can be changed using the =tag= option (see below). For
-%   example:
+%   The version 7 _dict_ type is supported as well.  Optionally,  if
+%   the dict has a _tag_,  a property  "type":"tag"  can be added to
+%   the object.  This behaviour can be controlled using the  =tag=
+%   option (see below). For example:
 %
 %     ==
 %     ?- json_write(current_output, point{x:1,y:2}).
+%     {
+%       "x":1,
+%       "y":2
+%     }
+%     ==
+%
+%     ==
+%     ?- json_write(current_output, point{x:1,y:2}, [tag(type)]).
 %     {
 %       "type":"point",
 %       "x":1,
@@ -904,7 +912,7 @@ is_json_pair(Options, Name=Value) :-
 %     * JSON =true=, =false= and =null= are represented using these
 %       Prolog atoms.
 %     * JSON objects are mapped to dicts.
-%     * By default, a =type= field in an object assigns a tag for
+%     * Optionally, a =type= field in an object assigns a tag for
 %       the dict.
 %
 %   The predicate json_read_dict/3 processes  the   same  options as


### PR DESCRIPTION
The documentation example json_write disagreed with actual behavior when pasted into swipl unless the 'tag' option is provided. The observed behavior is consistent with the description of the 'tag' option (which would disable "type":"tag" output by default), however, elsewhere the documentation suggests tag(type) rather than tag('') is the default.

This PR updates the documentation to match the implemented behavior of json_write, and adds a second example to clarify behavior with and without the 'tag' option.