### PR TITLE
FIXED: handling of defaults at end of json_object

### DIFF
--- a/json_convert.pl
+++ b/json_convert.pl
@@ -618,6 +618,17 @@ match_fields([Name=JSON|TP], [f(OptName, Type, Def, Prolog)|TF], Body,
     ),
     Q1 is Q0-1,
     match_fields([Name=JSON|TP], TF, Body, M, Q1, Q).
+match_fields([], [f(OptName, Type, Def, Prolog)|TF], Body,
+             M, Q0, Q) :-
+    !,
+    (   nullable(Type)
+    ->  true
+    ;   no_default(NoDef),
+        Def \== NoDef
+    ->  Prolog = Def
+    ),
+    Q1 is Q0-1,
+    match_fields([], TF, Body, M, Q1, Q).
 match_fields([Name=_|TP], [F|TF], Body, M, Q0, Q) :-
     arg(1, F, Next),
     Name @< Next,


### PR DESCRIPTION
The following was not properly working:
:- json_object point(x:integer, y:integer, z:integer=0).
json_to_prolog(json([x=5,y=6]), PrologTerm).

PrologTerm would not be properly instantiated because default values
were not being handled. Defaults worked properly in the middle of the
definition in json_object, but not at the end.

This patch fixes the problem.