### PR TITLE
FIXED: pwp finding index.pwp and directory handling

### DIFF
--- a/http_pwp.pl
+++ b/http_pwp.pl
@@ -140,10 +140,8 @@ pwp_handler(QOptions, Request) :-
     ;   Term = Spec
     ),
     http_safe_file(Term, Options),
-    (   absolute_file_name(Term, Path, [access(read), file_type(directory)])
-    ->  true
-    ;   absolute_file_name(Term, Path, [access(read)])
-    ),
+    absolute_file_name(Term, Path),
+    access_file(Path,read),
     (   exists_directory(Path)
     ->  ensure_slash(Path, Dir),
         (   (   member(index(Index), Options)

--- a/http_pwp.pl
+++ b/http_pwp.pl
@@ -140,7 +140,10 @@ pwp_handler(QOptions, Request) :-
     ;   Term = Spec
     ),
     http_safe_file(Term, Options),
-    absolute_file_name(Term, Path, [access(read)]),
+    (   absolute_file_name(Term, Path, [access(read), file_type(directory)])
+    ->  true
+    ;   absolute_file_name(Term, Path, [access(read)])
+    ),
     (   exists_directory(Path)
     ->  ensure_slash(Path, Dir),
         (   (   member(index(Index), Options)


### PR DESCRIPTION
* The logic to find index.pwp stopped working
  because absolute_file_name/3 only works with files
  unless file_type(directory) is specified as an option.

* This patch fixes the problem and  closes
  SWI-Prolog/swipl-devel#345