### PR TITLE
Accept status codes 201 thru 299 as successful

### DIFF
--- a/http_open.pl
+++ b/http_open.pl
@@ -669,12 +669,16 @@ add_method(Options0, Options) :-
     Options = [method(post)|Options0].
 add_method(Options0, [method(get)|Options0]).
 
+successful_code(Code) :-
+    Code >= 200,
+    Code < 300.
 
 %!  do_open(+HTTPVersion, +HTTPStatusCode, +HTTPStatusComment, +Header,
 %!          +Options, +Parts, +Host, +In, -FinalIn) is det.
 %
-%   Handle the HTTP status. If 200, we   are ok. If a redirect, redo
-%   the open, returning a new stream. Else issue an error.
+%   Handle the HTTP status once available. If 200-299, we are ok. If a
+%   redirect, redo the open, returning a new stream. Else issue an
+%   error.
 %
 %   @error  existence_error(url, URL)
 
@@ -717,7 +721,7 @@ do_open(Version, Code, _, Lines, Options, Parts, Host, In0, In) :-
     (   option(status_code(Code), Options),
         Lines \== []
     ->  true
-    ;   Code == 200
+    ;    successful_code(Code)
     ),
     !,
     parts_uri(Parts, URI),


### PR DESCRIPTION
Current behavior of http_open without an explicit status_code option is to throw an existance error for status codes 201 through 299.
This is explicitly incorrect for 201 (created), 202 (accepted), 203 (non-authoritative), 204 (no content), 205(reset content), and 206 (partial content). It is expected behavior for all other 201-299 codes.

[RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)

This PR causes http_open to treat status codes 201-299 as equivalent to 200 when there is no explicit status_code option.

Behavior of HEAD
?- http_open:http_open('https://httpstat.us/200', Stream, []), open_null_stream(Null), copy_stream_data(Stream, Null).
Stream = <stream>(0x558ddeb39e10,0x558ddeb39f20),
Null = <stream>(0x558ddeb3a030).

?- http_open:http_open('https://httpstat.us/201', Stream, []), open_null_stream(Null), copy_stream_data(Stream, Null).
ERROR: url `'https://httpstat.us/201'' does not exist (status(201,Created))
ERROR: In:
ERROR:   [12] throw(error(existence_error(url,'https://httpstat.us/201'),context(_686,...)))
ERROR:   [10] http_open:try_http_proxy(direct,'<garbage_collected>','<garbage_collected>','<garbage_collected>') at /home/anniepoo/.swivm/versions/7.7.18/lib/swipl-7.7.18/library/http/http_open.pl:418
ERROR:    [8] '<meta-call>'('<garbage_collected>') <foreign>
ERROR:    [7] <user>
ERROR: 
ERROR: Note: some frames are missing due to last-call optimization.
ERROR: Re-run your program in debug mode (:- debug.) to get more detail.
?- 

following change

?- http_open:http_open('https://httpstat.us/201', Stream, []), open_null_stream(Null), copy_stream_data(Stream, Null).
Stream = <stream>(0x558dde9d7a50,0x558ddea0f1e0),
Null = <stream>(0x558dde73f050).

?- 

?- http_open:http_open('https://httpstat.us/201', Stream, [status_code(Code)]), open_null_
Stream = <stream>(0x558dde6bf040,0x558ddea09620),
Code = 201,
Null = <stream>(0x558dde6b33a0).