### PR TITLE
Add samesite attribute to session cookies

### DIFF
--- a/http_session.pl
+++ b/http_session.pl
@@ -129,7 +129,7 @@ session_option(route, atom).
 session_option(enabled, boolean).
 session_option(proxy_enabled, boolean).
 session_option(gc, oneof([active,passive])).
-session_option(samesite, oneof([lax,strict])).
+session_option(samesite, oneof([none,lax,strict])).
 
 %!  http_set_session_options(+Options) is det.
 %
@@ -177,12 +177,14 @@ session_option(samesite, oneof([lax,strict])).
 %           session is created.
 %
 %           * samesite(+Restriction)
-%           One of lax (default), or strict - The
+%           One of `none`, `lax` (default), or `strict` - The
 %           SameSite attribute prevents the CSRF vulnerability.
 %           strict has best security, but prevents links from
 %           external sites from operating properly. lax stops most
 %           CSRF attacks against REST endpoints but rarely interferes
-%           with legitimage operations.
+%           with legitimage operations. `none` removes the samesite
+%           attribute entirely - **Caution: This exposes the entire
+%           site to CSRF attacks.**
 
 http_set_session_options([]).
 http_set_session_options([H|T]) :-
@@ -362,8 +364,14 @@ create_session(Request0, Request, SessionID) :-
     session_setting(path(Path)),
     session_setting(samesite(SameSite)),
     debug(http_session, 'Created session ~q at path=~q', [SessionID, Path]),
-    format('Set-Cookie: ~w=~w; Path=~w; Version=1; SameSite=~w\r\n',
-           [Cookie, SessionID, Path, SameSite]),
+    (   SameSite = none
+    ->
+        format('Set-Cookie: ~w=~w; Path=~w; Version=1\r\n',
+           [Cookie, SessionID, Path])
+    ;
+        format('Set-Cookie: ~w=~w; Path=~w; Version=1; SameSite=~w\r\n',
+           [Cookie, SessionID, Path, SameSite])
+    ),
     Request = [session(SessionID)|Request0],
     peer(Request0, Peer),
     open_session(SessionID, Peer).


### PR DESCRIPTION
This PR closes a vulnerability in sessions whereby a third site can forge authorization to REST services on a SWI-Prolog web framework server, via the [Cross Site Resource Forgery(CSRF)](https://www.owasp.org/index.php/SameSite) exploit.

[Most modern browsers ](https://caniuse.com/#search=samesite) support the SameSite attribute for Set-Cookie. Suppose a user browses good.org (a prolog site) and obtains a session cookie by logging in.   The user now visits evil.com.
evil.com may now make REST requests of  good.swi-prolog.org via normal AJAX calls. The session cookie will be provided.
If the SameSite attribute is set to lax or strict, the browser will refuse the request.
Setting to lax allows cross site requests in certain circumstances (eg links) that are usually benign. Setting to strict prevents, for example, making a link to a protected swish page work even if I'm currently logged into swish. So I've made 'lax' the default.
The current only choice (no attribute) is wrong in almost all cases.
This PR should have minimal impact on existing users, and closes a serious security vulnerability.
