### PR TITLE
After line 143, there should be a cut. Added a '!'

### DIFF
--- a/mimepack.pl
+++ b/mimepack.pl
@@ -141,6 +141,7 @@ pack(Name=Value, Out) :-
     ),
     pack(Value, Out).
 pack(html(HTML), Out) :-
+    !,
     format(Out, 'Content-Type: text/html\r\n\r\n', []),
     print_html(Out, HTML).
 pack(file(File), Out) :-


### PR DESCRIPTION
I tested this '!' locally and it fixed a problem. I needed to change some use_module-predicates, to get my mime_pack2 to compile.

```
    POSSIBILITY OF SUCH DAMAGE.
*/

:- module(mime_pack2,
          [ mime_pack/3                 % +Input, +Stream, ?Boundary
          ]).
:- use_module(library(http/mimetype)).    % local file needed adding library() to work
:- use_module(library(http/html_write)).   % local file needed adding library() to work
:- use_module(library(lists)).
:- use_module(library(error)).

/** <module> Create a MIME message

Simple and partial implementation of MIM
```