### PR TITLE
Add a json:json_write_hook/4 hook to allow for end-user control over …

### DIFF
--- a/json.pl
+++ b/json.pl
@@ -588,6 +588,11 @@ json_write_term(List, Stream, State, Options) :-
         indent(Stream, State),
         write(Stream, ']')
     ).
+
+:-multifile(json_write_hook/4).
+json_write_term(Term, Stream, State, Options):-
+    json_write_hook(Term, Stream, State, Options),
+    !.
 json_write_term(Number, Stream, _State, _Options) :-
     number(Number),
     !,


### PR DESCRIPTION
…objects

This is a PR for #128.

As an example, you could have hooks like this:
```
:-multifile(json:json_write_hook/4).

% All rationals get printed to 80 decimal places
json:json_write_hook(N, Stream, _State, _Options):-
        rational(N),
        format(Stream, '~80f', [N]).

% The special term fixed_precision/2 prints a term to the given number of decimal places
json:json_write_hook(fixed_precision(Value, Scale), Stream, _State, _Options):-
        format(Stream, '~*f', [Scale, Value]).
```

For example
```
?- json_write(user_error, _{fraction: 1 rdiv 3}, []).
{"fraction":0.33333333333333333333333333333333333333333333333333333333333333333333333333333333}
true.

?- json_write(user_error, _{fraction: fixed_precision(1 rdiv 9, 7)}, []).
{"fraction":0.1111111}
true.
```

I've put the hook after the instantiation check and the check for sub-json terms, but I'm happy if you want it to be first instead.