### PR TITLE
FIXED: library(http_open): Include the path/1 in the parsed URL so th…

### DIFF
--- a/http_open.pl
+++ b/http_open.pl
@@ -1238,6 +1238,7 @@ parse_url_ex(URL, [uri(URL)|Parts]) :-
 
 components(Components) -->
     uri_scheme(Components),
+    uri_path(Components),
     uri_authority(Components),
     uri_request_uri(Components).
 
@@ -1247,6 +1248,13 @@ uri_scheme(Components) -->
     [ scheme(Scheme)
     ].
 uri_scheme(_) --> [].
+
+uri_path(Components) -->
+    { uri_data(path, Components, Path), nonvar(Path) },
+    !,
+    [ path(Path)
+    ].
+uri_path(_) --> [].
 
 uri_authority(Components) -->
     { uri_data(authority, Components, Auth), nonvar(Auth),

--- a/http_open.pl
+++ b/http_open.pl
@@ -1250,7 +1250,12 @@ uri_scheme(Components) -->
 uri_scheme(_) --> [].
 
 uri_path(Components) -->
-    { uri_data(path, Components, Path), nonvar(Path) },
+    { uri_data(path, Components, Path0), nonvar(Path0),
+      (   Path0 == ''
+      ->  Path = (/)
+      ;   Path = Path0
+      )
+    },
     !,
     [ path(Path)
     ].


### PR DESCRIPTION
…at http_cookie can correctly use it to identify cookies with specific paths to be included in requests. Failure to include path/1 means that http_cookie will default to / which is not correct