### PR TITLE
Remove spurious newline from WWW-Authenticate header lines

### DIFF
--- a/http_header.pl
+++ b/http_header.pl
@@ -1854,19 +1854,19 @@ auth_field_value(negotiate(Data)) -->
     { base64(Data, DataBase64),
       atom_codes(DataBase64, Codes)
     },
-    string(Codes), "\r\n".
+    string(Codes).
 auth_field_value(negotiate) -->
-    "Negotiate\r\n".
+    "Negotiate".
 auth_field_value(basic) -->
     !,
-    "Basic\r\n".
+    "Basic".
 auth_field_value(basic(Realm)) -->
-    "Basic Realm=\"", atom(Realm), "\"\r\n".
+    "Basic Realm=\"", atom(Realm), "\"".
 auth_field_value(digest) -->
     !,
-    "Digest\r\n".
+    "Digest".
 auth_field_value(digest(Details)) -->
-    "Digest ", atom(Details), "\r\n".
+    "Digest ", atom(Details).
 
 %!  value_options(+List, +Field)//
 %


### PR DESCRIPTION
It looks like both auth_field_value//1 and header_field//2 emit a \r\n pair after succeeding. This means that after a WWW-Authenticate line, there are two \r\n pairs. Ordinarily this isn't _that_ much of a problem - you just lose some headers and maybe emit some junk into the body, but browsers will ignore it if there's no Content-Length or Content-Type and just prompt the user for a password if the WWW-Authenticate is basic.

But if it's Negotiate, then the lines afterwards _can_ be critical: For example, cookies set in the first step may be needed to establish a session so that the second step can find the authentication context to continue the authentication.

To be clear, the headers look like this
```
HTTP/1.1 401 Authorization Required
Date: Thu, 02 Apr 2020 06:02:55 GMT
WWW-Authenticate: Negotiate <blob>

Connection: close
Set-Cookie: se_session=b0a0-0458-8dfb-ec15.sepdk; path=/
Content-Length: 562
Content-Type: text/html; charset=UTF-8
```

Which means the body and the Set-Cookie and the Connection are all effectively ignored by browsers as junk.