### PR TITLE
Autoload library(uri)

### DIFF
--- a/thread_httpd.pl
+++ b/thread_httpd.pl
@@ -57,6 +57,7 @@
 :- use_module(http_wrapper).
 :- use_module(http_path).
 
+:- autoload(library(uri), [uri_resolve/3]).
 
 :- predicate_options(http_server/2, 2,
                      [ port(any),


### PR DESCRIPTION
Otherwise, trying to start a server with autoloading disabled gives an error about "`Unknown procedure: thread_httpd:uri_resolve/3`"