### PR TITLE
Add `gone 410` to list of status replies

### DIFF
--- a/http_header.pl
+++ b/http_header.pl
@@ -479,6 +479,7 @@ status_reply(Status, Out, Options) :-
 status_has_content(created(_Location)).
 status_has_content(moved(_To)).
 status_has_content(moved_temporary(_To)).
+status_has_content(gone(_URL)).
 status_has_content(see_other(_To)).
 status_has_content(bad_request(_ErrorTerm)).
 status_has_content(authorise(_Method)).
@@ -585,6 +586,16 @@ status_page_hook(moved_temporary(To), html_tokens(HTML), _Options) :-
                 [ h1('Moved Temporary'),
                   p(['The document is currently ',
                      a(href(To), ' Here')
+                    ]),
+                  \address
+                ]),
+           HTML).
+status_page_hook(gone(URL), html_tokens(HTML), _Options) :-
+    phrase(page([ title('301 Moved Permanently')
+                ],
+                [ h1('Resource Gone'),
+                  p(['The document has been removed ',
+                     a(href(URL), ' from here')
                     ]),
                   \address
                 ]),
@@ -1316,6 +1327,7 @@ status_reply_headers(moved(To, Body), Body,
                      [ location(To) ]).
 status_reply_headers(moved_temporary(To, Body), Body,
                      [ location(To) ]).
+status_reply_headers(gone(_URL, Body), Body, []).
 status_reply_headers(see_other(To, Body), Body,
                      [ location(To) ]).
 status_reply_headers(authorise(Method, Body), Body,


### PR DESCRIPTION
The TUS protocol for expiration (https://tus.io/protocols/resumable-upload.html#expiration) suggests that 410 Gone is used to represent the removal of expired resources when the expiry is still known.

For this reason I've added a patch which makes it possible to use `http_status_reply(gone(URL), Headers, Code)`