### PR TITLE
FIXED: Ping and pong frames may contain non-utf8 "Application data"

### DIFF
--- a/websocket.c
+++ b/websocket.c
@@ -73,7 +73,7 @@ typedef enum ws_opcode
   WS_OP_BINARY   = 2,
   WS_OP_CLOSE    = 8,
   WS_OP_PING     = 9,
-  WS_OP_PONG	 = 10
+  WS_OP_PONG     = 10
 } ws_opcode;
 
 
@@ -725,6 +725,8 @@ ws_start_message(term_t WsStream, term_t OpCode, term_t RSV)
     ctx->payload_written = 0;
     switch(opcode)
     { case WS_OP_BINARY:
+      case WS_OP_PING:
+      case WS_OP_PONG:
       case WS_OP_CLOSE:			/* first two bytes for the code */
 	Ssetenc(ctx->ws_stream, ENC_OCTET, NULL);
         break;
@@ -879,6 +881,8 @@ ws_read_header(term_t WsStream, term_t OpCode, term_t RSV)
 
   switch(ctx->opcode)
   { case WS_OP_BINARY:
+    case WS_OP_PING:
+    case WS_OP_PONG:
     case WS_OP_CLOSE:
       Ssetenc(ctx->ws_stream, ENC_OCTET, NULL);
       break;


### PR DESCRIPTION
According to RFC 6455, section 5.5.2:

_A Ping frame MAY include "Application data"._

But it does not mandate the "Application data" to be in UTF-8 encoding. Assuming UTF-8 breaks compatibility with other WebSocket libraries.