### PR TITLE
FIXED: Also escape line terminators when writing graphql strings

### DIFF
--- a/graphql.pl
+++ b/graphql.pl
@@ -1182,6 +1182,10 @@ graphql_write_pair(N-V, Options) -->
     graphql_write_value(V, Options).
 
 
+%! graphql_write_string(+Codes, +Options)// is det.
+%
+%  Generates Codes, except that codes in Codes that are not allowed in
+%  GraphQL string values are replaced by their escape sequences.
 graphql_write_string([], _Options) --> !, [].
 graphql_write_string([0'\"|T], Options) -->
     !,
@@ -1190,6 +1194,14 @@ graphql_write_string([0'\"|T], Options) -->
 graphql_write_string([0'\\|T], Options) -->
     !,
     "\\\\",
+    graphql_write_string(T, Options).
+graphql_write_string([0'\n|T], Options) -->
+    !,
+    "\\n",
+    graphql_write_string(T, Options).
+graphql_write_string([0'\r|T], Options) -->
+    !,
+    "\\r",
     graphql_write_string(T, Options).
 graphql_write_string([H|T], Options) -->
     [H],

--- a/test_graphql.pl
+++ b/test_graphql.pl
@@ -54,3 +54,24 @@ test(round_trip) :-
     graphql_read_document(codes(Codes), Doc, []).
 
 :- end_tests(graphql_round_trip).
+
+
+:- begin_tests(graphql_strings).
+
+test(escape_line_terminators) :-
+    String = "Hello,\r\nnewline!",
+    graphql_document_to_string(
+        {| graphql(String) ||
+           query { foo(bar: <String>
+                       baz: """
+                            Hello,
+                            multi-
+                            lines!
+                            """
+                      ) } |},
+        Text,
+        []
+    ),
+    string_lines(Text, [_]).
+
+:- end_tests(graphql_strings).


### PR DESCRIPTION
I stumbled upon this issue while porting my `sourcehut.pl` package to use the new `library(http/graphql)`:

As per https://spec.graphql.org/draft/#StringCharacter, GraphQL does not allow for line terminators (`\r` and/or `\n`) to occur in regular string literals (they are allowed in block strings, which use `"""` instead of `"` as delimiters). This is in contrast to Prolog strings, which do not impose this limitation.
Hence, line terminators that occur in Prolog strings must be escaped This mismatch gave rise to an issue when they are incorporated in GraphQL, e.g. via quasi-quotation.

This PR adds escaping for line terminators in strings written as part of `graphql_document_to_{codes,string}/3`, and adds a relevant test case.

