### PR TITLE
change redis_server/2 to redis_server/3 in documentation

### DIFF
--- a/http_session.pl
+++ b/http_session.pl
@@ -200,7 +200,7 @@ session_option(samesite, oneof([none,lax,strict])).
 %   options:
 %
 %     - redis_db(+DB)
-%       Alias name of the redis database to access.  See redis_server/2.
+%       Alias name of the redis database to access.  See redis_server/3.
 %     - redis_prefix(+Atom)
 %       Prefix to use for all HTTP session related keys.  Default is
 %       `'swipl:http:session'`


### PR DESCRIPTION
I was reading trough the documentation and noticed a reference to `redis_server/2` which does not seem to exist any more.