### PR TITLE
BUILD: Add zlib to doc generation dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ has_package(ssl HAVE_SSL_PACKAGE)
 if(HAVE_SSL_PACKAGE)
   set(doc_depends ssl)
 endif()
+has_package(zlib HAVE_ZLIB_PACKAGE)
+if(HAVE_ZLIB_PACKAGE)
+  list(APPEND doc_depends zlib)
+endif()
 
 if(SWIPL_WITH_HTTP_SERVER)
   set(HTTP_SECTION_FILES


### PR DESCRIPTION
## Summary
- The `http.doc.html` target runs `swipl` via `latex2html` to generate HTML documentation
- Processing the HTTP library transitively loads `library(zlib)`, which requires `zlib4pl` to be built
- Without an explicit dependency on the `zlib` target, parallel builds can schedule documentation generation before `zlib4pl` is available, causing the build to fail with `open_shared_object/3: The specified module could not be found.`
- Adds `zlib` to `doc_depends` (guarded by `has_package(zlib ...)`) so CMake orders the build correctly

## Files Changed
- `CMakeLists.txt`: Add `zlib` to documentation generation dependencies, matching the pattern used for `ssl`

## Test Plan
- [x] Verified that `zlib4pl.dll` is built at line 10074 in the build log, but `http.doc.html` fails at line 8929 (before zlib is available)
- [x] Confirmed `swipl` can load `library(zlib)` successfully when `zlib4pl.dll` is present
- [ ] Full rebuild with the fix to verify doc generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)